### PR TITLE
fix(scripts): fix resolve:crcomlib

### DIFF
--- a/template.json
+++ b/template.json
@@ -30,7 +30,7 @@
             "build:deploy:web": "yarn ch5-cli deploy -p -H $npm_package_crestron_project_web_url -t $npm_package_crestron_project_web_type dist/$npm_package_name.ch5z",
             "build:onestep:touchscreen": "yarn build && yarn build:archive && yarn build:deploy:touchscreen",
             "build:onestep:web": "yarn build && yarn build:archive && yarn build:deploy:web",
-            "resolve:crcomlib": "jq '.main = \"build_bundles/cjs/cr-com-lib.js\"' $npm_package_crestron_crcomlib_packageJson | sponge $npm_package_crestron_crcomlib_packageJson",
+            "resolve:crcomlib": "./node_modules/node-jq/bin/jq '.main = \"build_bundles/cjs/cr-com-lib.js\"' $npm_package_crestron_crcomlib_packageJson | sponge $npm_package_crestron_crcomlib_packageJson",
             "lint": "eslint .",
             "lint:fix": "eslint --fix .",
             "commit": "git-cz",


### PR DESCRIPTION
The resolve:crcomlib script will fail if the jq binary is not installed globally on the local machine. As node-jq installs a local copy of the jq binary into node_modules, this binary should be used so the script runs successfully regardless of if the user has jq installed on their local machine or not.